### PR TITLE
优化docker时区

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ nodejs>=18
 
 仓库地址：https://hub.docker.com/r/yafoo/pushme-server
 ```bash
-docker run -dit -p 3010:3010 -p 3100:3100 -v $PWD/pushme-server/config:/pushme-server/config --name pushme-server --restart unless-stopped yafoo/pushme-server:latest
+docker run -dit -p 3010:3010 -p 3100:3100 -e TZ=Asia/Shanghai -v $PWD/pushme-server/config:/pushme-server/config --name pushme-server --restart unless-stopped yafoo/pushme-server:latest
 ```
 
 #### 二、源码安装

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:18.20.4-alpine3.20
 ENV NODE_ENV=production
+ENV TZ=Asia/Shanghai
 
 EXPOSE 3010 3100
 VOLUME /config


### PR DESCRIPTION
默认docker是+0时区的，所以通知到手机后，显示的时间会慢8个小时，鉴于这个是国人项目，将docker默认设为+8时区，当然如果需要其他时区，部署时也能通过`-e`参数修改。